### PR TITLE
Fix weight logs user check

### DIFF
--- a/src/hooks/useWeightLogs.ts
+++ b/src/hooks/useWeightLogs.ts
@@ -52,7 +52,7 @@ export const useWeightLogs = (showMore: boolean = false) => {
 
   const addWeight = async (weight: number) => {
     try {
-      const user = supabase.auth.getUser();
+      const { data: { user } } = await supabase.auth.getUser();
       if (!user) {
         throw new Error("User not authenticated");
       }
@@ -60,10 +60,12 @@ export const useWeightLogs = (showMore: boolean = false) => {
       console.log('Adding weight log:', { weight });
       const { error } = await supabase
         .from('weight_logs')
-        .insert([{ 
-          weight,
-          user_id: (await user).data.user?.id 
-        }]);
+        .insert([
+          {
+            weight,
+            user_id: user.id
+          }
+        ]);
 
       if (error) throw error;
 


### PR DESCRIPTION
## Summary
- ensure user retrieval awaits `getUser` in weight logs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877d0d10414832798f5433e68de9073